### PR TITLE
Halved value returned by gapBetweenThumbs function

### DIFF
--- a/RangeSlider/RangeSlider.swift
+++ b/RangeSlider/RangeSlider.swift
@@ -112,7 +112,7 @@ class RangeSlider: UIControl {
     }
     
     var gapBetweenThumbs: Double {
-        return Double(thumbWidth)*(maximumValue - minimumValue) / Double(bounds.width)
+        return 0.5 * Double(thumbWidth) * (maximumValue - minimumValue) / Double(bounds.width)
     }
     
     @IBInspectable var trackTintColor = UIColor(white: 0.9, alpha: 1.0) {


### PR DESCRIPTION
Halved the gapBetweenThumbs value in order to allow the selection of smaller ranges (i.e., 31-32).

Fixes issue #7 